### PR TITLE
Loot tracker fix

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerBox.java
@@ -222,22 +222,6 @@ class LootTrackerBox extends JPanel
 		}
 	}
 
-	/**
-	 * Checks for record compatibility before checking record's last collapsed state
-	 * @param record to match
-	 * @return whether this box should be collapsed afer it's built
-	 */
-
-	boolean shouldCollapse(final LootTrackerRecord record)
-	{
-		if (!matches(record))
-		{
-			throw new IllegalArgumentException(record.toString());
-		}
-
-		return record.isBoxCollapsed();
-	}
-
 	void rebuild()
 	{
 		buildItems();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -34,10 +34,7 @@ import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.swing.BorderFactory;
@@ -120,6 +117,7 @@ class LootTrackerPanel extends PluginPanel
 	// Individual records for the individual kills this session
 	private final List<LootTrackerRecord> sessionRecords = new ArrayList<>();
 	private final List<LootTrackerBox> boxes = new ArrayList<>();
+	private final Map<String, Boolean> collapsedRecords = new HashMap<String, Boolean>();
 
 	private final ItemManager itemManager;
 	private final LootTrackerPlugin plugin;
@@ -381,6 +379,7 @@ class LootTrackerPanel extends PluginPanel
 		}
 		final LootTrackerRecord record = new LootTrackerRecord(eventName, subTitle, type, items, kills);
 		sessionRecords.add(record);
+		collapsedRecords.put(record.getTitle(), false);
 
 		if (hideIgnoredItems && plugin.isEventIgnored(eventName))
 		{
@@ -577,6 +576,12 @@ class LootTrackerPanel extends PluginPanel
 					{
 						box.collapse();
 					}
+
+					if (collapsedRecords.containsKey(box.getId()))
+					{
+						collapsedRecords.put(box.getId(), box.isCollapsed());
+					}
+
 					updateCollapseText();
 				}
 			}
@@ -640,7 +645,7 @@ class LootTrackerPanel extends PluginPanel
 		}
 
 		// Collapse box from record's previous boxCollapsed state
-		if (box.shouldCollapse(record))
+		if (collapsedRecords.get(box.getId()))
 		{
 			box.collapse();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -503,7 +503,7 @@ class LootTrackerPanel extends PluginPanel
 	 * This method decides what to do with a new record, if a similar log exists, it will
 	 * add its items to it, updating the log's overall price and kills. If not, a new log will be created
 	 * to hold this entry's information.
-	 * If a new log box is created and has a predecessor of the same record, the predecessor's collapsed state
+	 * If a new log box is created and a predecessor of the same record existed, the predecessor's collapsed state
 	 * is carried over to new log box.
 	 */
 	private LootTrackerBox buildBox(LootTrackerRecord record)
@@ -636,7 +636,6 @@ class LootTrackerPanel extends PluginPanel
 		}
 
 		// Collapse box if predecessor box was collapsed
-
 		if (collapsedRecords.containsKey(box.getId()))
 		{
 			BoxState previousState = collapsedRecords.get(box.getId());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPanel.java
@@ -503,6 +503,8 @@ class LootTrackerPanel extends PluginPanel
 	 * This method decides what to do with a new record, if a similar log exists, it will
 	 * add its items to it, updating the log's overall price and kills. If not, a new log will be created
 	 * to hold this entry's information.
+	 * If a new log box is created and has a predecessor of the same record, the predecessor's collapsed state
+	 * is carried over to new log box.
 	 */
 	private LootTrackerBox buildBox(LootTrackerRecord record)
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerRecord.java
@@ -39,12 +39,6 @@ class LootTrackerRecord
 	private final int kills;
 
 	/**
-	 * If record is new, the box that will be built with it will not be instantiated
-	 * in a collapsed state.
-	 */
-	boolean boxCollapsed = false;
-
-	/**
 	 * Checks if this record matches specified id
 	 *
 	 * @param id other record id


### PR DESCRIPTION
# Fixed By ghaz0

Fixed:
* Loot Tracker Boxes remembering previous collapsed state when the `ignore items` button is toggled